### PR TITLE
Fixed crash in the IsHindrance callback caused by custom 'invalid' en…

### DIFF
--- a/source/actions_constructor.cpp
+++ b/source/actions_constructor.cpp
@@ -97,7 +97,7 @@ nb_action_ptr ActionConstructor::Execute(IPluginContext* ctx, const cell_t* para
 		void* param = (void*)paramsBuffer[i];
 
 		const ActionEncoder& encoder = *(m_paramEncoder[i]);
-		if (!encoder(param, error, maxlength))
+		if (!encoder.encode(param, error, maxlength))
 		{
 			throw std::runtime_error(error);
 		}
@@ -148,7 +148,7 @@ bool ActionConstructor::AddParameter(PassType type, int flags, const ActionEncod
 
 	const int maxlength = 255;
 	char error[maxlength] = {};
-	if (encoder && !(*encoder)(info, error, maxlength))
+	if (encoder && !encoder->typeinfo(info, error, maxlength))
 	{
 		throw std::runtime_error(error);
 		return false;

--- a/source/actions_encoders.h
+++ b/source/actions_encoders.h
@@ -13,7 +13,7 @@ class CBaseEntityEncoder : public TypeEncoder<cell_t>
 public:
 	CBaseEntityEncoder() : TypeEncoder("g_entityEncoder", "entity")
 	{
-		paramEncoder = [](encode_param_ref_t param, char* error, size_t maxlength) -> bool
+		m_param_encoder = [](encode_param_ref_t param, char* error, size_t maxlength) -> bool
 		{
 			cell_t index = *param;
 			CBaseEntity* entity = nullptr;
@@ -36,12 +36,12 @@ class CVectorEncoder : public TypeEncoder<Vector>
 public:
 	CVectorEncoder() : TypeEncoder("g_vectorEncoder", "vector")
 	{
-		paramEncoder = [](encode_param_ref_t param, char* error, size_t maxlength) -> bool
+		m_param_encoder = [](encode_param_ref_t param, char* error, size_t maxlength) -> bool
 		{
 			return true;
 		};
 
-		passEncoder = [this](PassInfo& info, char* error, size_t maxlength) -> bool
+		m_type_encoder = [this](PassInfo& info, char* error, size_t maxlength) -> bool
 		{
 			switch (info.type)
 			{

--- a/source/actions_propagation.h
+++ b/source/actions_propagation.h
@@ -112,7 +112,8 @@ public:
 		{
 			cell_t entity = -1;
 
-			if (arg != nullptr)
+			/* https://github.com/Vinillia/actions.ext/issues/24 */
+			if ((void*)arg != (void*)0xFFFFFFFF && arg != nullptr)
 				entity = gamehelpers->EntityToBCompatRef((CBaseEntity*)arg);
 
 			fn->PushCell(entity);

--- a/source/smsdk_config.h
+++ b/source/smsdk_config.h
@@ -40,7 +40,7 @@
 /* Basic information exposed publicly */
 #define SMEXT_CONF_NAME			"Actions"
 #define SMEXT_CONF_DESCRIPTION	"Nextbot action tree manager"
-#define SMEXT_CONF_VERSION		"3.7.6"
+#define SMEXT_CONF_VERSION		"3.7.7"
 #define SMEXT_CONF_AUTHOR		"BHaType"
 #define SMEXT_CONF_URL			"http://www.sourcemod.net/"
 #define SMEXT_CONF_LOGTAG		"Actions"

--- a/sourcemod/include/actions.inc
+++ b/sourcemod/include/actions.inc
@@ -11,13 +11,26 @@
 #include <actions_processors>
 #include <actions_constructor>
 
+/*
+ * Several plugins may provide a similar API. 
+ * Use the defines below to disable the corresponding definition.
+ * 
+ * #define _disable_actions_query_result_type
+ * #define _disable_actions_action_result_type
+ * #define _disable_actions_event_result_priority_type
+ * 
+ */
+
+#if !defined _disable_actions_query_result_type
 enum QueryResultType
 {
 	ANSWER_NO,
 	ANSWER_YES,
 	ANSWER_UNDEFINED
 };
+#endif
 
+#if !defined _disable_actions_action_result_type
 enum ActionResultType
 { 
 	CONTINUE,			// continue executing this action next frame - nothing has changed
@@ -26,7 +39,9 @@ enum ActionResultType
 	DONE,				// this action has finished, resume suspended action
 	SUSTAIN,			// for use with event handlers - a way to say "It's important to keep doing what I'm doing"
 };
+#endif
 
+#if !defined _disable_actions_event_result_priority_type
 enum EventResultPriorityType
 {
 	RESULT_NONE,		// no result
@@ -34,6 +49,7 @@ enum EventResultPriorityType
 	RESULT_IMPORTANT,	// try extra-hard to use this result
 	RESULT_CRITICAL		// this result must be used - emit an error if it can't be
 };
+#endif
 
 enum BehaviorAction
 {
@@ -848,6 +864,20 @@ methodmap BehaviorAction < BehaviorActionListeners
 		out[0] = view_as<float>(this.Get(offset, NumberType_Int32));
 		out[1] = view_as<float>(this.Get(offset + 4, NumberType_Int32));
 		out[2] = view_as<float>(this.Get(offset + 8, NumberType_Int32));
+	}
+
+ 	/**
+ 	* @brief Checks if action matches specified name
+ 	*
+ 	* @param name			Name to check against 
+ 	*
+ 	* @return 				true actions matches name, false otherwise 
+ 	*/
+	public bool Matches(const char[] match)
+	{
+		char name[ACTION_NAME_LENGTH];
+		this.GetName(name, sizeof name);
+		return !strcmp(name, match);
 	}
 
 	/**


### PR DESCRIPTION
…tity definition (closes #24)

Added BehaviorAction.Matches function to replace the GetName() + strcmp idiom 
Definitions provided by the include can now be disabled with the preprocessor